### PR TITLE
Fix creation of files with empty merge ops

### DIFF
--- a/src/Operations/MergeOperation.php
+++ b/src/Operations/MergeOperation.php
@@ -152,10 +152,19 @@ class MergeOperation extends AbstractOperation {
       return new ScaffoldResult($destination, FALSE);
     }
 
-    // Make sure the directory exists.
-    $fs->ensureDirectoryExists(dirname($destination_path));
+    // If the generated content from the "merge" source is empty,
+    // then do not create (or rewrite) an empty file.
+    if (empty($new_contents)) {
+      $io->write($interpolator->interpolate("  - Skipping <info>[dest-full-path]</info> because source is empty."), TRUE, 4);
+      return new ScaffoldResult($destination, FALSE);
+    }
     // Copy the new contents to the destination.
-    return $this->copyScaffold($destination, $io, $new_contents);
+    else {
+      // Make sure the directory exists.
+      $fs->ensureDirectoryExists(dirname($destination_path));
+      // Copy the new contents to the destination.
+      return $this->copyScaffold($destination, $io, $new_contents);
+    }
   }
 
   /**


### PR DESCRIPTION
## Issue

When there is a template source asset file with a `merge` operation that has conditional content, and therefore can be empty, it will create an empty file if the file didn't exist before and the resolved is also empty. This is not the intended behavior. It should only create a new file if the source file has content.

## How to reproduce

Template example source `./assets/example.yml.twig` in an example asset package:

```twig
{% if if foo.bar == "baz" %}
foo: bar
{% endif %}
```

This will create an empty `example.yml` if `foo.bar` is not equal `baz`.

## Tasks

- [x] Fix creation of files with empty source files on `merge` operations