### PR TITLE
Fix error if file destination doesn't exist

### DIFF
--- a/src/Operations/AddOperation.php
+++ b/src/Operations/AddOperation.php
@@ -139,11 +139,18 @@ class AddOperation extends AbstractOperation {
       }
       return new ScaffoldResult($destination, FALSE);
     }
-    // Copy the new contents to the destination.
+    // If there is content try to write the content.
     else {
-      // Make sure the directory exists.
-      $fs->ensureDirectoryExists(dirname($destination_path));
-      return $this->copyScaffold($destination, $io, $new_contents);
+      try {
+        // Make sure the directory exists.
+        $fs->ensureDirectoryExists(dirname($destination_path));
+        // Copy the new contents to the destination.
+        return $this->copyScaffold($destination, $io, $new_contents);
+      }
+      catch (\Exception $e) {
+        $io->write($interpolator->interpolate("  - Could not write <info>[dest-full-path]</info>: <warning>" . $e->getMessage() . "</warning>"));
+        return new ScaffoldResult($destination, FALSE);
+      }
     }
   }
 

--- a/src/Operations/MergeOperation.php
+++ b/src/Operations/MergeOperation.php
@@ -158,12 +158,18 @@ class MergeOperation extends AbstractOperation {
       $io->write($interpolator->interpolate("  - Skipping <info>[dest-full-path]</info> because source is empty."), TRUE, 4);
       return new ScaffoldResult($destination, FALSE);
     }
-    // Copy the new contents to the destination.
+    // If there is content try to write the content.
     else {
-      // Make sure the directory exists.
-      $fs->ensureDirectoryExists(dirname($destination_path));
-      // Copy the new contents to the destination.
-      return $this->copyScaffold($destination, $io, $new_contents);
+      try {
+        // Make sure the directory exists.
+        $fs->ensureDirectoryExists(dirname($destination_path));
+        // Copy the new contents to the destination.
+        return $this->copyScaffold($destination, $io, $new_contents);
+      }
+      catch (\Exception $e) {
+        $io->write($interpolator->interpolate("  - Could not write <info>[dest-full-path]</info>: <warning>" . $e->getMessage() . "</warning>"));
+        return new ScaffoldResult($destination, FALSE);
+      }
     }
   }
 


### PR DESCRIPTION
## Issue

When a destination location doesn't exist or permissions aren't sufficient the scaffolding will throw an exception and error out. However there are scenarios where some destinations might not be accessible (or writable) during the execution and it should only show a warning and continue nonetheless.

This is the case for example when there is a build environment that doesn't have access to project-level files, but only to app- and web-level files (e.g. platform.sh).

## How to reproduce

* Set a location to a path that is inaccessible/inexistant
  * e.g.: `project-scaffold.locations.project-root`: `"../../.."`.
* Try scaffolding a asset in the project root.

## Tasks

- [x] Fix the hard error exception if a file destination doesn't exist or permissions are insufficient