### PR TITLE
Add support for conditional questions

### DIFF
--- a/src/Operations/ReadOperation.php
+++ b/src/Operations/ReadOperation.php
@@ -100,6 +100,27 @@ class ReadOperation extends AbstractOperation {
       $io->write("Configure <comment>{$package_name}</comment>:", TRUE, 2);
 
       foreach ($scaffold_questions["questions"] as $variable => $definition) {
+        // Sanitize variable name if there are multiples,
+        // e.g. `example[0]` to `example`.
+        $variable = preg_replace('/\[.+/', "", $variable);
+
+        // If this a conditional question, make sure to resolve condition.
+        if (array_key_exists("if", $definition) && count($definition["if"]) == 1) {
+          $conditional_variable = array_key_first($definition["if"]);
+          $conditional_value = array_values($definition["if"])[0];
+
+          // If the condition doesn't match, continue.
+          if (in_array($conditional_variable, $scaffold_variable_keys)) {
+            $current_value = $interpolator->interpolate($this->getScaffoldVariable($conditional_variable, $scaffold_variables));
+            if ($current_value !== $conditional_value) {
+              continue;
+            }
+          }
+          else {
+            continue;
+          }
+        }
+
         $value = "";
         // If a default was defined set the value to it.
         if (array_key_exists("default", $definition)) {


### PR DESCRIPTION
## Feature

There might be scenarios where a question in the `questions.json` should be asked conditionally based on a previous answer. This would enable more complex interactive prompts.

## Example

Imagine the scenario where there are multiple deployment environments. Depending on the deployment environment the name is either a fixed list of options or a user defined string with validation. In one case there might also be an additional variable necessary.

<details>
<summary>Example `questions.json`</summary>
<br>

```json
{
    "required": [
        "deployment",
        "deployment_environment"
    ],
    "questions": {
        "deployment": {
            "question": "Where is the App <info>deployment</info>?",
            "default": "primary",
            "options": [
                "primary",
                "secondary"
            ]
        },
        "deployment_environment[0]": {
            "if": {
                "deployment": "primary"
            },
            "question": "What is the target <info>Deployment Environment</info>?",
            "default": "stage",
            "options": [
                "dev",
                "stage",
                "prod"
            ]
        },
        "deployment_environment[1]": {
            "if": {
                "deployment": "secondary"
            },
            "question": "What is the target <info>Deployment Environment</info>?",
            "validation": ".+?-.+"
        },
        "deployment_project_id": {
            "if": {
                "deployment": "secondary"
            },
            "question": "What is the <info>project ID</info>?"
        }
    }
}
```

</details>

## Tasks

- [x] Add support for conditional questions in the `questions.json`