### PR TITLE
Fix plugin support during lock update

### DIFF
--- a/src/Handler.php
+++ b/src/Handler.php
@@ -354,7 +354,6 @@ class Handler {
       '--lock' => TRUE,
       '--no-autoloader' => TRUE,
       '--no-install' => TRUE,
-      '--no-plugins' => TRUE,
       '--no-scripts' => TRUE,
       '--interactive' => FALSE,
       '--ignore-platform-reqs' => TRUE,


### PR DESCRIPTION
## Issue

If the composer file is modified by `project-scaffold` during `composer update` or `composer require` then the lock file will also be updated in `updateComposerLock()` with the `--lock` option. To prevent the function from calling itself and thus ending up in a loop, the `--no-plugins` flag was added. However if composer plugin is required during the lock update, e.g. when using `mglaman/composer-drupal-lenient` for package dependency resolution, then the `updateComposerLock()` could fail.

## Tasks

- [x] Add support for plugins in `updateComposerLock()`
- [x] Make sure there is no loop in `postCmd()`