### PR TITLE
Fix YAML custom tag parsing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": ">=7.3.0",
     "composer-plugin-api": "^2.0",
-    "symfony/yaml": "^3.0 || ^4.0 || ^5.0 || ^6.0",
+    "symfony/yaml": "^4.0 || ^5.0 || ^6.0 || ^7.0",
     "twig/twig": "^2.0 || ^3.0"
   },
   "autoload": {

--- a/src/Util/ContentMerger.php
+++ b/src/Util/ContentMerger.php
@@ -302,6 +302,11 @@ class ContentMerger {
 
         // Remove escaped single-quotes in comments.
         $merged_contents = preg_replace('/^(\s*#.*?)\'\'(.+?)\'\'/m', "$1'$2'", $merged_contents);
+
+        // Remove unncessary newline at the end of the file.
+        if (substr($merged_contents, -2) === "\n\n") {
+          $merged_contents = substr($merged_contents, 0, -1);
+        }
       }
       else {
         $merged_contents = $yaml_contents;

--- a/src/Util/ContentMerger.php
+++ b/src/Util/ContentMerger.php
@@ -2,8 +2,9 @@
 
 namespace iqual\Composer\ProjectScaffold\Util;
 
-use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\Yaml\Tag\TaggedValue;
 
 /**
  * Merge contents from a source by replacing the variables in the destination.
@@ -502,6 +503,12 @@ class ContentMerger {
     foreach ($a as $k => $v) {
       if (is_array($v)) {
         if (!self::arraysAreEqual($v, $b[$k])) {
+          return FALSE;
+        }
+      }
+      // Check for TaggedValue objects.
+      elseif ($v instanceof TaggedValue && $b[$k] instanceof TaggedValue) {
+        if ($v->getTag() !== $b[$k]->getTag() || !self::arraysAreEqual((array) $v->getValue(), (array) $b[$k]->getValue())) {
           return FALSE;
         }
       }

--- a/src/Util/ContentMerger.php
+++ b/src/Util/ContentMerger.php
@@ -183,7 +183,7 @@ class ContentMerger {
 
       // Convert the processed YAML contents to an array.
       try {
-        $contents_array = Yaml::parse($converted_contents);
+        $contents_array = Yaml::parse($converted_contents, Yaml::PARSE_CUSTOM_TAGS);
       }
       catch (ParseException $exception) {
         throw new \RuntimeException("Could not parse YAML file. Error: " . $exception->getMessage());


### PR DESCRIPTION
## Issue

If there is a YAML file going through a merge operation that uses custom tags (e.g. `!archive`), then the operation will fail.

## Task

- [x] Fix YAML custom tag parsing (add `Yaml::PARSE_CUSTOM_TAGS`)